### PR TITLE
Better support for Windows paths

### DIFF
--- a/lib/paths-provider.coffee
+++ b/lib/paths-provider.coffee
@@ -7,7 +7,7 @@ module.exports =
 class PathsProvider
   id: 'autocomplete-paths-pathsprovider'
   selector: '*'
-  wordRegex: /[a-zA-Z0-9\.\/_-]*\/[a-zA-Z0-9\.\/_-]*/g
+  wordRegex: /(?:[a-zA-Z]:)?[a-zA-Z0-9./\\_-]*(?:\/|\\\\?)[a-zA-Z0-9./\\_-]*/g
   cache: []
 
   requestHandler: (options = {}) =>
@@ -55,7 +55,7 @@ class PathsProvider
 
     prefixPath = path.resolve(basePath, prefix.replace(/^\//, ''))
 
-    if prefix.endsWith('/')
+    if prefix.match(/[/\\]$/)
       directory = prefixPath
       prefix = ''
     else
@@ -89,7 +89,6 @@ class PathsProvider
         continue
       if stat.isDirectory()
         label = 'Dir'
-        result += path.sep
       else if stat.isFile()
         label = 'File'
       else

--- a/lib/paths-provider.coffee
+++ b/lib/paths-provider.coffee
@@ -7,7 +7,7 @@ module.exports =
 class PathsProvider
   id: 'autocomplete-paths-pathsprovider'
   selector: '*'
-  wordRegex: /(?:[a-zA-Z]:)?[a-zA-Z0-9./\\_-]*(?:\/|\\\\?)[a-zA-Z0-9./\\_-]*/g
+  wordRegex: /(?:[a-zA-Z]\:)?[a-zA-Z0-9\ \.\\\/\_\-]*(?:\/|\\\\?)[a-zA-Z0-9\ \.\\\/\_\-]*/g
   cache: []
 
   requestHandler: (options = {}) =>

--- a/spec/autocomplete-paths-spec.coffee
+++ b/spec/autocomplete-paths-spec.coffee
@@ -72,7 +72,7 @@ describe 'Autocomplete Snippets', ->
 
       runs ->
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('linkeddir/')
+        expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('linkeddir')
         # expect(editorView.querySelector('.autocomplete-plus span.completion-label')).toHaveText('Dir')
 
     it 'does not crash when typing an invalid folder', ->
@@ -93,7 +93,7 @@ describe 'Autocomplete Snippets', ->
     #     expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
     #
     #     editor.moveToBottom()
-    #     editor.insertText(c) for c in './linkedir'
+    #     editor.insertText(c) for c in './linkeddir'
     #
     #     advanceClock(completionDelay)
     #
@@ -101,8 +101,11 @@ describe 'Autocomplete Snippets', ->
     #     autocompleteManager.displaySuggestions.calls.length is 1
     #
     #   runs ->
-    #     # Select linkeddir/
+    #     # Select linkeddir
     #     atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
+    #     advanceClock(completionDelay)
+    #
+    #     editor.insertText('/')
     #     advanceClock(completionDelay)
     #
     #   waitsFor ->


### PR DESCRIPTION
Exact copy of https://github.com/atom-community/autocomplete-paths/pull/51, which fixes showing showing "\\" at end of path.